### PR TITLE
Add CSRF protection to news deletion

### DIFF
--- a/public/panelNoticias/actions/eliminarNoticia.php
+++ b/public/panelNoticias/actions/eliminarNoticia.php
@@ -1,10 +1,22 @@
 <?php
 session_start();
-$id = trim($_GET['id'] ?? '');
+
 if (!isset($_SESSION['usuario']) || empty($_SESSION['usuario']['permNoticia'])) {
     http_response_code(403);
     exit("Acceso no autorizado");
 }
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit("Método no permitido");
+}
+
+if (empty($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'])) {
+    http_response_code(403);
+    exit("Token CSRF inválido");
+}
+
+$id = trim($_POST['id'] ?? '');
 require_once __DIR__ . '/../../../backend/includes/db.php';
 include "../includes/jsonLoader.php";
 

--- a/public/panelNoticias/panelNoticias.php
+++ b/public/panelNoticias/panelNoticias.php
@@ -8,6 +8,10 @@ if (!isset($_SESSION['usuario'])) {
 
 $usuario = $_SESSION['usuario'];
 
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
 require_once __DIR__ . '/../../backend/includes/db.php';
 include "./includes/jsonLoader.php";
 
@@ -72,7 +76,11 @@ $noticias = array_reverse($noticias);
                         <div class="contenido-noticia"><?= $noticia['contenido'] ?></div>
                         <div class="mt-2 flex flex-col sm:flex-row sm:space-x-4 space-y-2 sm:space-y-0">
                             <a href="./actions/editarNoticia.php?id=<?= $noticia['id'] ?>" class="text-blue-600 hover:underline">Editar</a>
-                            <a href="./actions/eliminarNoticia.php?id=<?= $noticia['id'] ?>" class="text-red-600 hover:underline" onclick="return confirm('¿Seguro que deseas eliminar esta noticia?');">Eliminar</a>
+                            <form action="./actions/eliminarNoticia.php" method="POST" onsubmit="return confirm('¿Seguro que deseas eliminar esta noticia?');">
+                                <input type="hidden" name="id" value="<?= $noticia['id'] ?>">
+                                <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?>">
+                                <button type="submit" class="text-red-600 hover:underline">Eliminar</button>
+                            </form>
                         </div>
                     </li>
                 <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Generate CSRF token and include it in news deletion forms
- Verify CSRF token and POST method in deletion action

## Testing
- `php -l public/panelNoticias/panelNoticias.php`
- `php -l public/panelNoticias/actions/eliminarNoticia.php`


------
https://chatgpt.com/codex/tasks/task_e_689d37831cf8832fa5519f5dcbb8d36b